### PR TITLE
Enable to generate routes for another app

### DIFF
--- a/DependencyInjection/MultipleAppKernelExtension.php
+++ b/DependencyInjection/MultipleAppKernelExtension.php
@@ -7,6 +7,7 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
 /**
  * This is the class that loads and manages your bundle configuration
@@ -28,5 +29,8 @@ class MultipleAppKernelExtension extends Extension
                 '%kernel.commons_dir%/Resources',
             ))
         ));
+
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('services.xml');
     }
 }

--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ abstract class BaseKernel extends Kernel
     {
         $bundles = array(
             // ...
-            
+
             // Multiple App
             new MultipleApp\KernelBundle\MultipleAppKernelBundle(),
         );
-        
+
         // ...
-        
+
         return $bundles;
     }
 }
@@ -78,7 +78,7 @@ Apps files are located in each app folder. Each app folder (like `/backend`) sho
 #!/usr/bin/env php
 <?php
     // ...
-    
+
     require_once __DIR__.'/../commons/bootstrap.php.cache';
     require_once __DIR__.'/AppKernel.php';
 
@@ -105,7 +105,7 @@ class AppKernel extends BaseKernel
         );
 
         // ...
-        
+
         return $bundles;
     }
 
@@ -120,7 +120,22 @@ class AppKernel extends BaseKernel
 # Config files
 
 In project folders, common resources may be included like :
-      
+
 ``` php
     - { resource: "../../commons/config/config.yml" }
+```
+
+# Generate multi apps routes
+
+``` php
+$this->get('multiapp.routing_generator')
+     // generate($appName, $name, $parameters = array(), $absolute = false)
+     ->generate('frontend', 'myroute', array('page' => $Page, '_locale' => 'fr'), true);
+```
+
+For absolute url define in parameters.yml :
+
+```
+parameters:
+    multiapp.frontend.base_url: http://example.com
 ```

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+<!--  List Templating Merger -->
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="multiapp.routing_generator.class">MultipleApp\KernelBundle\Routing\Generator</parameter>
+    </parameters>
+
+    <services>
+        <service id="multiapp.routing_generator" class="%multiapp.routing_generator.class%" public="true">
+            <argument type="service" id="service_container" />
+        </service>
+    </services>
+</container>

--- a/Routing/Generator.php
+++ b/Routing/Generator.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace MultipleApp\KernelBundle\Routing;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+* This class help to build routes using the other app router
+*/
+class Generator
+{
+    protected $container;
+
+    /**
+    * @param ContainerInterface the symfony container
+    */
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+    * generate route using other routing generator
+    *
+    * @param string app name
+    * @param string route name
+    * @param array route params
+    * @param boolean should we need to generate an absolute url
+    *
+    * @return string the url generated
+    * @throws Symfony\Component\Routing\Exception\RouteNotFoundException if route do not exists
+    */
+    public function generate($appName, $name, $parameters = array(), $absolute = false)
+    {
+        $appUrlGenerator = $this->getAppUrlGenerator($appName);
+        $url = $appUrlGenerator->generate($name, $parameters);
+
+        // Fix controller name
+        $url = str_replace($this->container->getParameter('kernel.name'), $appName, $url);
+
+        // Manage absolue url
+        if ($absolute) {
+            $url = $this->container->getParameter('multiapp.'.$appName.'.base_url').$url;
+        }
+
+        return $url;
+    }
+
+    /**
+    * Get the appEnvUrlGenerator from the cache of the other app (eg frontenddevUrlGenerator)
+    *
+    * @param string $appName the name of application
+    * @return Symfony\Component\Routing\Generator\UrlGenerator
+    */
+    protected function getAppUrlGenerator($appName)
+    {
+        // Load the route generator for app
+        $cache_dir = str_replace($this->container->getParameter('kernel.name'), $appName, $this->container->getParameter('kernel.cache_dir'));
+        $generatorClassName = $appName.$this->container->getParameter('kernel.environment').'UrlGenerator';
+        require_once $cache_dir.DIRECTORY_SEPARATOR.$generatorClassName.'.php';
+
+        return new $generatorClassName($this->container->get('router.request_context'));
+    }
+}


### PR DESCRIPTION
# Generate multi apps routes

``` php
$this->get('multiapp.routing_generator')
     // generate($appName, $name, $parameters = array(), $absolute = false)
     ->generate('frontend', 'myroute', array('page' => $Page, '_locale' => 'fr'), true);
```

For absolute url define in parameters.yml :

```
parameters:
    multiapp.frontend.base_url: http://example.com
```
