### PR TITLE
Adding slash before and after kernel and app name

### DIFF
--- a/Routing/Generator.php
+++ b/Routing/Generator.php
@@ -55,7 +55,9 @@ class Generator
     protected function getAppUrlGenerator($appName)
     {
         // Load the route generator for app
-        $cache_dir = str_replace($this->container->getParameter('kernel.name'), $appName, $this->container->getParameter('kernel.cache_dir'));
+        $kernelName = '/'.$this->container->getParameter('kernel.name').'/';
+        $appName = '/'.$appName.'/';
+        $cache_dir = str_replace($kernelName, $appName, $this->container->getParameter('kernel.cache_dir'));
         $generatorClassName = $appName.ucfirst($this->container->getParameter('kernel.environment')).'UrlGenerator';
         require_once $cache_dir.DIRECTORY_SEPARATOR.$generatorClassName.'.php';
 


### PR DESCRIPTION
This fixes the case where $appName is contained in another part of the full path and it gets replaced by mistake.